### PR TITLE
Allocate single frame APNG in DecodeConfig

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1086,6 +1086,7 @@ func DecodeConfig(r io.Reader) (image.Config, error) {
 	d := &decoder{
 		r:   r,
 		crc: crc32.NewIEEE(),
+		a:   APNG{Frames: make([]Frame, 1)},
 	}
 	if err := d.checkHeader(); err != nil {
 		if err == io.EOF {

--- a/reader_test.go
+++ b/reader_test.go
@@ -5,6 +5,7 @@
 package apng
 
 import (
+	"image/color"
 	"os"
 	"testing"
 )
@@ -71,4 +72,32 @@ func ReadAPNG(path string) (APNG, error) {
 	}
 
 	return a, err
+}
+
+func TestDecodeConfig(t *testing.T) {
+	f, err := os.Open("tests/WithDefaultFrame.png")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer f.Close()
+
+	cfg, err := DecodeConfig(f)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if cfg.Width != 200 {
+		t.Error("Expected 200 pixels wide.")
+		return
+	}
+	if cfg.Height != 239 {
+		t.Error("Expected 239 pixels high.")
+		return
+	}
+	if cfg.ColorModel != color.RGBAModel {
+		t.Error("Expected RGBA color model.")
+		return
+	}
 }


### PR DESCRIPTION
Fixes a panic when calling `DecodeConfig` due to missing first frame.