### PR TITLE
Reset encoder seq field after acquiring from buffer pool

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -647,7 +647,7 @@ func (enc *Encoder) Encode(w io.Writer, a APNG) error {
 	if enc.BufferPool != nil {
 		buffer := enc.BufferPool.Get()
 		e = (*encoder)(buffer)
-
+		e.seq = 0
 	}
 	if e == nil {
 		e = &encoder{}


### PR DESCRIPTION
This change ensures that the `seq` field of the `encoder` is reset to 0 immediately after being retrieved from the buffer pool. This guarantees a clean state for reused encoder instances, preventing potential logic errors due to stale `seq` values. The reset is performed only in the buffer pool branch, as newly created encoders are initialized with a default `seq` value of 0.